### PR TITLE
chore: update minSdk to 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.mparticle.kit'
 
 android {
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
     }
 }
 dependencies {


### PR DESCRIPTION
# Summary

upgrade to minSdk 16 to match the underlying Iterable SDK
