### PR TITLE
feat: Incorporate allowedProtocols when building config

### DIFF
--- a/src/main/kotlin/com/iterable/iterableapi/IterableConfigHelper.kt
+++ b/src/main/kotlin/com/iterable/iterableapi/IterableConfigHelper.kt
@@ -13,6 +13,7 @@ object IterableConfigHelper {
                 setLogLevel(config.logLevel)
                 setInAppHandler(config.inAppHandler)
                 setInAppDisplayInterval(config.inAppDisplayInterval)
+                setAllowedProtocols(config.allowedProtocols)
             }
         }
         return builder


### PR DESCRIPTION
## Summary
- Even though dependabots have been pointing to latest IterableSDK, mparticleKit has not been updated to accommodate new parameter - `allowedProtocols` that could be passed by developers. Hence the change to accommodate `allowedProtocols`

## Testing Plan
- Has not been tested
