### PR TITLE
fix: Adds in new preference for userId primary identity

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/IterableKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/IterableKit.kt
@@ -204,11 +204,6 @@ class IterableKit : KitIntegration(), ActivityListener, ApplicationStateListener
                 }
             })
         }
-
-
-
-
-
     }
 
     override fun willHandlePushMessage(intent: Intent): Boolean {


### PR DESCRIPTION
 ## Summary
 - Adds a new configuration to use the userId instead of creating a placeholder email for the mparticle identity.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally to ensure a new user was created on mParticle with a userId instead of a placeholder email.